### PR TITLE
Youtube parser fixes

### DIFF
--- a/src/Parsers/YouTubeParser.php
+++ b/src/Parsers/YouTubeParser.php
@@ -55,7 +55,7 @@ class YouTubeParser extends BaseParser implements ParserInterface
         $this->getPreview()
             ->setId($matches[1])
             ->setEmbed(
-                '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/'.$this->getPreview()->getId().'" frameborder="0"/>'
+                '<iframe id="ytplayer" type="text/html" width="640" height="390" src="//www.youtube.com/embed/'.$this->getPreview()->getId().'" frameborder="0"></iframe>'
             );
 
         return $this;


### PR DESCRIPTION
Hi,

I had problem using the embed part on a HTTPS website. So I used "//" instead of "http://" on the generated iframe URL. It is now protocol independant and will play in every site.

I also fixed the self closing iframe tag. On some browser, it causes some weird problems.
http://stackoverflow.com/questions/27545757/why-is-a-self-closing-iframe-tag-preventing-further-dom-elements-to-be-displayed
