### PR TITLE
Update attribute names for twitter cards

### DIFF
--- a/src/Parsers/HtmlParser.php
+++ b/src/Parsers/HtmlParser.php
@@ -24,13 +24,13 @@ class HtmlParser extends BaseParser implements ParserInterface
      */
     private $tags = [
         'cover' => [
-            ['selector' => 'meta[property="twitter:image"]', 'attribute' => 'value'],
+            ['selector' => 'meta[property="twitter:image"]', 'attribute' => 'content'],
             ['selector' => 'meta[property="og:image"]', 'attribute' => 'content'],
             ['selector' => 'meta[itemprop="image"]', 'attribute' => 'content'],
         ],
 
         'title' => [
-            ['selector' => 'meta[property="twitter:title"]', 'attribute' => 'value'],
+            ['selector' => 'meta[property="twitter:title"]', 'attribute' => 'content'],
             ['selector' => 'meta[property="og:title"]', 'attribute' => 'content'],
             ['selector' => 'meta[itemprop="name"]', 'attribute' => 'content'],
             ['selector' => 'title']


### PR DESCRIPTION
In the HTML parser, the attribute name was set to `value` rather than
`content` for the `twitter:image` and `twitter:title` selectors. Per
Twitter’s documentation, this attribute should be `content`. (See:
https://dev.twitter.com/cards/types/summary) This causes valid HTML
pages with correct Twitter card syntax to return an empty cover and
title. For example, this URL:
http://www.huffingtonpost.com/entry/the-missing-voice-the-missing-piece-
where-are-the_us_576f5617e4b0fa01a14027df