### PR TITLE
allow version 6 of symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "php": ">=5.5.0",
         "illuminate/support": "5.*|6.*|7.*|8.*",
         "guzzlehttp/guzzle": "^6.1|^7.1",
-        "symfony/dom-crawler": "^3.0|^4.0|^5.0",
-        "symfony/css-selector": "^3.0|^4.0|^5.0"
+        "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Allow composer to install version 6 of symfony/dom-crawler and symfony/css-selector
Note: I have not tested this